### PR TITLE
Update to support ampersand characters in sign data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ nzsl.db
 picture/*
 nzsl-dictionary-android
 nzsl-dictionary-ios
-*-bak

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dnzsl-xmldump.xml
 nzsl.dat
 nzsl.db
 picture/*
+nzsl-dictionary-android
+nzsl-dictionary-ios
+*-bak

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	  docker build . -t rabid/nzsl-dictionary-scripts
+		git clone git://github.com/rabid/nzsl-dictionary-ios.git
+		git clone git://github.com/rabid/nzsl-dictionary-android.git
+update_assets:
+	docker run --rm -it -v $(shell pwd)/nzsl-dictionary-android:/usr/src/android-app -v $(shell pwd)/nzsl-dictionary-ios:/usr/src/ios-app -v $(shell pwd):/usr/src/app rabid/nzsl-dictionary-scripts -i /usr/src/ios-app -a /usr/src/android-app
+	 

--- a/build-assets.py
+++ b/build-assets.py
@@ -2,6 +2,7 @@
 from optparse import OptionParser
 import sys
 import os
+import re
 import xml.etree.ElementTree as ET
 import shutil
 
@@ -42,7 +43,12 @@ with open(filename) as f:
     data = f.read()
 data = data.replace("\x05", "")
 data = data.replace("<->", "")
-root = ET.fromstring(data)
+
+# Replace ampersands, which are XML control characters, with
+# the appropriate XML escape sequence
+data = re.sub(r"&(?=[^#])", "&#038;", data)
+parser = ET.XMLParser(encoding="UTF-8")
+root = ET.XML(data, parser=parser)
 
 print("Step 2: Fetching images from freelex")
 freelex.fetch_assets(root)


### PR DESCRIPTION
Recent updates to the dictionary have introduced signs that have usage instructions including ampersand characters (for example "L&P"). We cannot do a straight substitution here, because ampersand characters also have meaning when used as entity references. This patch adds a regex that replaces ampersand characters that are _not_ trailed by a '#' character with the appropriate sequence for an ampersand character to be ultimately rendered.