### PR TITLE
Force video urls to use mp4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ nzsl.db
 picture/*
 nzsl-dictionary-android
 nzsl-dictionary-ios
-*-bak

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dnzsl-xmldump.xml
 nzsl.dat
 nzsl.db
 picture/*
+nzsl-dictionary-android
+nzsl-dictionary-ios
+*-bak

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	  docker build . -t rabid/nzsl-dictionary-scripts
+		git clone git://github.com/rabid/nzsl-dictionary-ios.git
+		git clone git://github.com/rabid/nzsl-dictionary-android.git
+update_assets:
+	docker run --rm -it -v $(shell pwd)/nzsl-dictionary-android:/usr/src/android-app -v $(shell pwd)/nzsl-dictionary-ios:/usr/src/ios-app -v $(shell pwd):/usr/src/app rabid/nzsl-dictionary-scripts -i /usr/src/ios-app -a /usr/src/android-app
+	 

--- a/freelex.py
+++ b/freelex.py
@@ -60,7 +60,7 @@ def write_datfile(root):
                 sec.text if sec is not None else "",
                 maori.text if maori is not None else "",
                 os.path.basename(picture.text) if picture is not None else "",
-                "http://freelex.nzsl.vuw.ac.nz/dnzsl/freelex/assets/"+video.text if video is not None else   "",
+                "http://freelex.nzsl.vuw.ac.nz/dnzsl/freelex/assets/"+video.text.replace(".webm", ".mp4") if video is not None else   "",
                 handshape.text if handshape is not None else "",
                 entry.find("location").text,
             ]), file=f)


### PR DESCRIPTION
NZSL has recently begun receiving recorded videos in webm format from their supplier. Unfortunately, iOS does not natively support webm. As a temporary but possibly permanent workaround, NZSL dictionary staff have agreed to transcode webm videos to mp4 and place them in the same folder structure as the webm files. 

This change to the script replaces any video filename with webm with mp4 which can be played in Android and iOS.