### PR TITLE
CC-2368: Support an old S3 deployment path as well since we are copying to public/ instead of production/

### DIFF
--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -39,7 +39,7 @@ jobs:
           SIGNBANK_WEB_READY_TAG_ID: ${{ vars.SIGNBANK_WEB_READY_TAG_ID }}
       - name: Upload nzsl.db to S3
         run: |
-          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME_OLD }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}
+          aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME_OLD }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH_OLD }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}
           aws s3 cp ./nzsl.db s3://${{ secrets.AWS_S3_BUCKET_NAME }}/${{ secrets.AWS_S3_DEPLOYMENT_PATH }}/nzsl.db --acl ${{ secrets.AWS_S3_DEPLOYMENT_ACL }}
       - name: Upload nzsl.db
         if: github.event.inputs.environment == 'Production'


### PR DESCRIPTION
What it says on the tin - we didn't need to adjust this before, but we do now - it's different between old and new approaches.