### PR TITLE
ci: update to actions that use node v24

### DIFF
--- a/.github/workflows/freelex-extract.yml
+++ b/.github/workflows/freelex-extract.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make build update_assets
       - run: tar -cf assets.tar.gz assets
       - name: Create Release

--- a/.github/workflows/signbank-database-extract.yml
+++ b/.github/workflows/signbank-database-extract.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Extracts and prepares Signbank database data, bypassing asset processing"
     environment: ${{ github.event.inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/signbank-extract.yml
+++ b/.github/workflows/signbank-extract.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: make build update_signbank_assets
         env:
           SIGNBANK_HOST: ${{ secrets.SIGNBANK_HOST }}


### PR DESCRIPTION
Addresses the deprecation warnings in ci by updating actions/checkout to a version using node v24, as runners using node v20 are deprecated

Release notes:
https://github.com/actions/checkout/releases/tag/v6.0.0